### PR TITLE
Removed the scrollbars on embedded notebooks

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -83,6 +83,23 @@
 				<div class = "embed-responsive embed-responsive-16by9">
 					<object data="{{ url_for('get_notebook', filename=post.notebook) }} " class = "embed-responsive-item"> Error with the notebook, or page, or something.</object>
 				</div>
+				<script>
+				  function resize() {
+				    //Grab the frame
+					var frame = document.getElementById("frame");
+					//Grab the div
+					var frameDiv = document.getElementById("frameDiv");
+					//Temporarily set the height
+					frame.style.height = '0px';
+					//Grab the actual scrollHeight
+					var sHeight = frame.contentWindow.document.body.scrollHeight + 30 + 'px';
+					//Use the scrollHeight to se the iframe's and div's height
+					//Using paddingBottom breaks the iframe
+					//Must adjust the div, otherwise the iframe will be hidden inside a smaller div
+					frame.style.height = sHeight;
+					frameDiv.style.height = sHeight;
+				  }
+				</script>
 			{% endif %}
           </div>
         </div>


### PR DESCRIPTION
Used Javascript to render the whole notebook, removing the need for scrollbars.
Changed to using iframe instead of object