### PR TITLE
Removed scrollbars from embedded notebooks

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -80,9 +80,26 @@
           <div class="col-lg-10 col-md-10 mx-auto">
             {{ post.html|safe }}
 			{% if post.notebook %}
-				<div class = "embed-responsive embed-responsive-16by9">
-					<object data="{{ url_for('get_notebook', filename=post.notebook) }} " class = "embed-responsive-item"> Error with the notebook, or page, or something.</object>
+				<div class = "embed-responsive" id = "frameDiv">
+					<iframe src="{{ url_for('get_notebook', filename=post.notebook) }} " class = "embed-responsive-item" onload = "resize()" id = "frame"> Error with the notebook, or page, or something.</iframe>
 				</div>
+				<script>
+				  function resize() {
+				    //Grab the frame
+					var frame = document.getElementById("frame");
+					//Grab the div
+					var frameDiv = document.getElementById("frameDiv");
+					//Temporarily set the height
+					frame.style.height = '0px';
+					//Grab the actual scrollHeight
+					var sHeight = frame.contentWindow.document.body.scrollHeight + 30 + 'px';
+					//Use the scrollHeight to se the iframe's and div's height
+					//Using paddingBottom breaks the iframe
+					//Must adjust the div, otherwise the iframe will be hidden inside a smaller div
+					frame.style.height = sHeight;
+					frameDiv.style.height = sHeight;
+				  }
+				</script>
 			{% endif %}
           </div>
         </div>


### PR DESCRIPTION
Embedded notebooks no longer need scrollbars to display content
Using iframe instead of object.
Known Issues: Height for div for embedding notebook is not consistent, chance on changing on reload to 1 of 2 values.